### PR TITLE
framedstream: Write whole message with single write call

### DIFF
--- a/transport/frame.go
+++ b/transport/frame.go
@@ -61,7 +61,7 @@ func (fs *FramedStream) WriteMsg(payload []byte) error {
 	msg = append(msg, payload...)
 
 	for i := 0; i < len(msg); i++ {
-		fmt.Printf("%d: %02x\n", i, msg[i])
+		fmt.Printf("%d: %02x", i, msg[i])
 	}
 
 	err := fs.writeBytesSafe(msg)

--- a/transport/frame.go
+++ b/transport/frame.go
@@ -24,6 +24,7 @@ limitations under the License.
 package transport
 
 import (
+	"fmt"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -58,6 +59,10 @@ func (fs *FramedStream) WriteMsg(payload []byte) error {
 	msg = append(msg, magicBytes...)
 	msg = append(msg, fs.genLength(uint(len(payload)))...)
 	msg = append(msg, payload...)
+
+	for i := 0; i < len(msg); i++ {
+		fmt.Printf("%d: %02x", i, msg[i])
+	}
 
 	err := fs.writeBytesSafe(msg)
 	return err

--- a/transport/frame.go
+++ b/transport/frame.go
@@ -24,7 +24,6 @@ limitations under the License.
 package transport
 
 import (
-	"fmt"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -59,10 +58,6 @@ func (fs *FramedStream) WriteMsg(payload []byte) error {
 	msg = append(msg, magicBytes...)
 	msg = append(msg, fs.genLength(uint(len(payload)))...)
 	msg = append(msg, payload...)
-
-	for i := 0; i < len(msg); i++ {
-		fmt.Printf("%d: %02x", i, msg[i])
-	}
 
 	err := fs.writeBytesSafe(msg)
 	return err

--- a/transport/frame.go
+++ b/transport/frame.go
@@ -61,7 +61,7 @@ func (fs *FramedStream) WriteMsg(payload []byte) error {
 	msg = append(msg, payload...)
 
 	for i := 0; i < len(msg); i++ {
-		fmt.Printf("%d: %02x", i, msg[i])
+		fmt.Printf("%d: %02x\n", i, msg[i])
 	}
 
 	err := fs.writeBytesSafe(msg)


### PR DESCRIPTION
Necessary, as some customer clients can't handle messages arriving in chunks