### PR TITLE
Minor fixes of analogintypea/binaryiotypea clients

### DIFF
--- a/analogintypea/client.go
+++ b/analogintypea/client.go
@@ -106,7 +106,7 @@ func (c *Client) DownloadConfiguration() (*Configuration, error) {
 // Value reads the current analog input level
 //
 // range -1 .. +1 (for min/max voltage or current)
-func (c *Client) Value(channel int) (float32, error) {
+func (c *Client) Value() (float32, error) {
 	any, err := c.fbClient.FunctionControlGet(&fspb.FunctionControlGet{})
 	if err != nil {
 		return float32(math.NaN()), err

--- a/binaryiotypea/client.go
+++ b/binaryiotypea/client.go
@@ -97,7 +97,7 @@ func (c *Client) UploadConfiguration(opts ...ConfigOption) error {
 
 	// set defaults
 	fsCmd := &fspb.ConfigurationSet{
-		OutputFrittingMask:    uint32(0x0f),
+		OutputFrittingMask:    uint32(0x00),
 		OutputWatchdogMask:    uint32(0x00),
 		OutputWatchdogTimeout: 0,
 	}

--- a/examples/analogInTypeA/value/main.go
+++ b/examples/analogInTypeA/value/main.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2021 Ci4Rail GmbH <engineering@ci4rail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	anain "github.com/ci4rail/io4edge-client-go/analogintypea"
+)
+
+func main() {
+	const timeout = 5 * time.Second
+
+	if len(os.Args) != 2 {
+		log.Fatalf("Usage: %s <mdns-service-address OR <ip:port>", os.Args[0])
+	}
+	address := os.Args[1]
+
+	// Create a client object to work with the io4edge device
+	c, err := anain.NewClientFromUniversalAddress(address, timeout)
+	if err != nil {
+		log.Fatalf("Failed to create anain client: %v\n", err)
+	}
+
+	// read current value
+	val, err := c.Value()
+	if err != nil {
+		log.Fatalf("Can't get value: %v\n", err)
+	}
+	fmt.Printf("Current value: %.4f\n", val)
+}


### PR DESCRIPTION
analogintypea: Remove channel parameter to Value()
analogintypea: Add "value" example
binaryiotypea: changed default value for frittig to be consistent with firmware (default=off)