### PR TITLE
Fix exec ttynvt

### DIFF
--- a/client/serviceobserver.go
+++ b/client/serviceobserver.go
@@ -10,6 +10,9 @@ import (
 
 func runServiceBrowser(domain string, serviceType string, addServiceChan chan ServiceInfo, removeServiceChan chan ServiceInfo) {
 	log.Debugf("starting service Browser for %s", serviceType)
+	if serviceType == "" {
+		return
+	}
 	sb, err := server.ServiceBrowserNew(avahi.InterfaceUnspec, avahi.ProtoUnspec, serviceType, domain, 0)
 	if err != nil {
 		log.Errorf("servicescan: can't start service browser for %s: %v", serviceType, err)
@@ -19,15 +22,17 @@ func runServiceBrowser(domain string, serviceType string, addServiceChan chan Se
 		var svcInf ServiceInfo
 		select {
 		case s := <-sb.AddChannel:
-			log.Debugf("browser got add service %s", s.Name)
-			s, err = server.ResolveService(s.Interface, s.Protocol, s.Name,
-				s.Type, s.Domain, avahi.ProtoUnspec, 0)
-			if err == nil {
-				svcInf.service = s
-				addServiceChan <- svcInf
-			} else {
-				log.Debugf("servicescan: can't resolve service %s: %v", serviceType, err)
-			}
+			log.Debugf("browser got add service %s if=%v prot=%v type=%v domain=%v", s.Name, s.Interface, s.Protocol, s.Type, s.Domain)
+			go func() {
+				s, err = server.ResolveService(s.Interface, s.Protocol, s.Name,
+					s.Type, s.Domain, avahi.ProtoUnspec, 0)
+				if err == nil {
+					svcInf.service = s
+					addServiceChan <- svcInf
+				} else {
+					log.Debugf("servicescan: can't resolve service %s: %v", s.Name, err)
+				}
+			}()
 		case s := <-sb.RemoveChannel:
 			log.Debugf("browser got rem service %s", s.Name)
 			svcInf.service = s

--- a/cmd/cli/cmd/scan.go
+++ b/cmd/cli/cmd/scan.go
@@ -150,6 +150,6 @@ func scan(cmd *cobra.Command, args []string) {
 
 func init() {
 	rootCmd.AddCommand(scanCmd)
-	scanCmd.PersistentFlags().UintVarP(&scanTime, "scantime", "", 8, "scan time in seconds")
+	scanCmd.PersistentFlags().UintVarP(&scanTime, "scantime", "", 2, "scan time in seconds")
 	scanCmd.PersistentFlags().BoolVarP(&enableShowFunctions, "functions", "f", false, "show device sub functions")
 }

--- a/cmd/exec-ttynvt/main.go
+++ b/cmd/exec-ttynvt/main.go
@@ -37,10 +37,12 @@ type ttynvtInstanceInfo struct {
 	ipPort string
 }
 
-var ttynvtInstanceMap = make(map[string]*ttynvtInstanceInfo)
-var programPath string
-var major int
-var minorMap [maxMinorNumbers]bool
+var (
+	ttynvtInstanceMap = make(map[string]*ttynvtInstanceInfo)
+	programPath       string
+	major             int
+	minorMap          [maxMinorNumbers]bool
+)
 
 func initMinorMap() {
 	for i := range minorMap {
@@ -159,6 +161,7 @@ func main() {
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS] <ttynvt-program-path> <driver-major-number>\n", os.Args[0])
+		flag.PrintDefaults()
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ci4rail/io4edge_api v0.6.0
 	github.com/gobwas/glob v0.2.3
 	github.com/godbus/dbus/v5 v5.0.5
-	github.com/holoplot/go-avahi v1.0.0
+	github.com/holoplot/go-avahi v1.0.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,6 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/holoplot/go-avahi v1.0.0 h1:PxtsRmfgj5Qkboc0YVXOrgwFPxVuX3GLo4P1swGU+ac=
-github.com/holoplot/go-avahi v1.0.0/go.mod h1:qH5psEKb0DK+BRplMfc+RY4VMOlbf6mqfxgpMy6aP0M=
 github.com/holoplot/go-avahi v1.0.1 h1:XcqR2keL4qWRnlxHD5CAOdWpLFZJ+EOUK0vEuylfvvk=
 github.com/holoplot/go-avahi v1.0.1/go.mod h1:qH5psEKb0DK+BRplMfc+RY4VMOlbf6mqfxgpMy6aP0M=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/holoplot/go-avahi v1.0.0 h1:PxtsRmfgj5Qkboc0YVXOrgwFPxVuX3GLo4P1swGU+ac=
 github.com/holoplot/go-avahi v1.0.0/go.mod h1:qH5psEKb0DK+BRplMfc+RY4VMOlbf6mqfxgpMy6aP0M=
+github.com/holoplot/go-avahi v1.0.1 h1:XcqR2keL4qWRnlxHD5CAOdWpLFZJ+EOUK0vEuylfvvk=
+github.com/holoplot/go-avahi v1.0.1/go.mod h1:qH5psEKb0DK+BRplMfc+RY4VMOlbf6mqfxgpMy6aP0M=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=


### PR DESCRIPTION
Exec ttynvt did not correctly handle situation where mdns services show up multiple times -> almost rewritten
Serviceobserver was stuck in waiting for resolver to get answers from non existing devices.
io4edge-cli scan time can be reduced because serviceobserver improved