### PR TITLE
fix mvbsniffer pcap recordings being misread by busshark dissector

### DIFF
--- a/examples/mvbSniffer/pcap/busshark/gen.go
+++ b/examples/mvbSniffer/pcap/busshark/gen.go
@@ -68,7 +68,7 @@ func Pkt(frameNumber uint64, receiveTime20nsUnits uint64, line int, frameType in
 	r = append(r, 0xc0, 0x01)
 
 	// fill
-	r = append(r, "MVBSNIFFER-Ci4Rail-Format 1.00"...)
+	r = append(r, "BUSSHARK-Ci4Rail-MVB-Vers:1.00"...)
 
 	// insert dummy CRCs, they have been removed by MVB sniffer
 	mvbDataInclCRCs := mvbDataWithCRCs(mvbData)


### PR DESCRIPTION
Since commit [c59eb17c](https://gitlab.com/busshark/busshark.dissectors.mvb/-/commit/[c59eb17c](https://gitlab.com/busshark/busshark.dissectors.mvb/-/commit/c59eb17c5b0386cabd49ee1ef80c6dfcfa9c4072)5b0386cabd49ee1ef80c6dfcfa9c4072), the Busshark MVB dissector for Wireshark detects the frame type by its fill string. To ensure a correct interpretation, the MVB sniffer's fill string must start with "BU" and end with ".00".